### PR TITLE
Handle retries by sub-rule

### DIFF
--- a/CiscoVM/CiscoVM-1.0.0/ciscovm_helpers.py
+++ b/CiscoVM/CiscoVM-1.0.0/ciscovm_helpers.py
@@ -35,10 +35,11 @@ class CVMHTTPClient:
     POST_EVENT_TYPE = "job-results"
     # Create a custom Retry object with max retries set to 3
     RETRY_STRATEGY = {
-        "total": 3,
+        "total": 1,
         "backoff_factor": 1,
         "status_forcelist": [408, 429, 500, 502, 503, 504]
     }
+    TIMEOUT_SECONDS = 60
 
     def __init__(self, url: str, uid: str, auth_token: str):
         self.full_url = f"{url.strip('/')}/{uid.strip('/').strip()}"
@@ -86,7 +87,8 @@ class CVMHTTPClient:
     @response_handler
     def ping(self) -> requests.Response:
         """Check connection to the service."""
-        return requests.post(self.full_url, headers=self._generate_headers())
+        return requests.post(self.full_url, headers=self._generate_headers(),
+                             timeout=self.TIMEOUT_SECONDS)
 
     @response_handler
     def post(self, data: dict) -> requests.Response:
@@ -95,6 +97,7 @@ class CVMHTTPClient:
             self.full_url,
             headers=self._generate_headers(self.POST_EVENT_TYPE),
             data=json.dumps(data),
+            timeout=self.TIMEOUT_SECONDS
         )
 
 

--- a/CiscoVM/CiscoVM-1.0.0/ciscovm_resolve.py
+++ b/CiscoVM/CiscoVM-1.0.0/ciscovm_resolve.py
@@ -39,9 +39,9 @@ try:
     if was_sent:
         properties["connect_ciscovm_exported"] = "true"
     else:
-        response["error"] = msg
+        properties["connect_ciscovm_exported"] = msg
 except Exception as e:
-    response["error"] = str(e)
+    properties["connect_ciscovm_exported"] = str(e)
     logging.error(str(e))
 finally:
     response["properties"] = properties

--- a/CiscoVM/CiscoVM-1.0.0/policies/nptemplates/ciscovm_exported.xml
+++ b/CiscoVM/CiscoVM-1.0.0/policies/nptemplates/ciscovm_exported.xml
@@ -1,17 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <RULES>
-    <RULE APP_VERSION="8.4.2-668" CACHE_TTL="259200" CACHE_TTL_SYNCED="true" CLASSIFICATION="REG_STATUS" DESCRIPTION="" ENABLED="true" ID="8320568346461085183" NAME="Cisco VM Devices" NOT_COND_UPDATE="true" UPGRADE_PERFORMED="true">
+    <RULE APP_VERSION="8.4.2-668" CACHE_TTL="259200" CACHE_TTL_SYNCED="true" CLASSIFICATION="REG_STATUS" DESCRIPTION="" ENABLED="true" ID="7949410565485933875" NAME="Cisco VM" NOT_COND_UPDATE="true" UPGRADE_PERFORMED="true">
         <GROUP_IN_FILTER/>
         <INACTIVITY_TTL TTL="259200000" USE_DEFAULT="true"/>
         <ADMISSION_RESOLVE_DELAY TTL="30000" USE_DEFAULT="true"/>
-        <MATCH_TIMING SKIP_INACTIVE="true">
-            <SCHEDULE FREQ="1" HOUR="3" MINUTE="0" REG="1696432426290" TYPE="DAY"/>
-        </MATCH_TIMING>
+        <MATCH_TIMING SKIP_INACTIVE="true"/>
         <EXPRESSION EXPR_TYPE="SIMPLE">
-            <!--Rule expression. Rule name is: Cisco VM Devices-->
-            <CONDITION EMPTY_LIST_VALUE="false" FIELD_NAME="connect_ciscovm_exported" LABEL="Cisco VM Exported" LEFT_PARENTHESIS="0" LOGIC="AND" RET_VALUE_ON_UKNOWN="IRRESOLVED" RIGHT_PARENTHESIS="0">
-                <FILTER CASE_SENSITIVE="false" FILTER_ID="-1604534803806789015" TYPE="equals">
-                    <VALUE VALUE2="true"/>
+            <!--Rule expression. Rule name is: Cisco VM-->
+            <CONDITION EMPTY_LIST_VALUE="false" FIELD_NAME="connect_ciscovm_exported" LABEL="Cisco VM Exported" LEFT_PARENTHESIS="0" LOGIC="AND" PLUGIN_NAME="Connect" PLUGIN_UNIQUE_NAME="connect_module" PLUGIN_VESRION="1.7.4" PLUGIN_VESRION_NUMBER="17040015" RET_VALUE_ON_UKNOWN="IRRESOLVED" RIGHT_PARENTHESIS="0">
+                <FILTER CASE_SENSITIVE="false" FILTER_ID="-6527407906135295596" TYPE="any">
+                    <VALUE VALUE2="Any"/>
                 </FILTER>
             </CONDITION>
         </EXPRESSION>
@@ -21,10 +19,47 @@
         <EXCEPTION NAME="user" UNKNOWN_EVAL="UNMATCH"/>
         <EXCEPTION NAME="group" UNKNOWN_EVAL="UNMATCH"/>
         <ORIGIN NAME="CUSTOM"/>
-        <UNMATCH_TIMING RATE="28800" SKIP_INACTIVE="true"/>
+        <UNMATCH_TIMING SKIP_INACTIVE="true"/>
         <RANGE FROM="0.0.0.0" TO="255.255.255.255"/>
         <SUBNET address="::" prefix="0"/>
-        <RULE_CHAIN/>
+        <RULE_CHAIN>
+            <INNER_RULE APP_VERSION="8.4.2-668" CACHE_TTL="259200" CACHE_TTL_SYNCED="true" CLASSIFICATION="REG_STATUS" DESCRIPTION="" ID="8984904902782325874" NAME="Exported" NOT_COND_UPDATE="true" RECHECK_MAIN_RULE_DEF="false">
+                <MATCH_TIMING SKIP_INACTIVE="true">
+                    <SCHEDULE FREQ="1" HOUR="0" MINUTE="0" REG="1697743773401" TYPE="DAY"/>
+                </MATCH_TIMING>
+                <EXPRESSION EXPR_TYPE="SIMPLE">
+                    <!--Rule expression. Rule name is: Exported-->
+                    <CONDITION EMPTY_LIST_VALUE="false" FIELD_NAME="connect_ciscovm_exported" LABEL="Cisco VM Exported" LEFT_PARENTHESIS="0" LOGIC="AND" PLUGIN_NAME="Connect" PLUGIN_UNIQUE_NAME="connect_module" PLUGIN_VESRION="1.7.4" PLUGIN_VESRION_NUMBER="17040015" RET_VALUE_ON_UKNOWN="IRRESOLVED" RIGHT_PARENTHESIS="0">
+                        <FILTER CASE_SENSITIVE="false" FILTER_ID="1090314693701632772" TYPE="equals">
+                            <VALUE VALUE2="true"/>
+                        </FILTER>
+                    </CONDITION>
+                </EXPRESSION>
+                <EXCEPTION NAME="ip" UNKNOWN_EVAL="UNMATCH"/>
+                <EXCEPTION NAME="mac" UNKNOWN_EVAL="UNMATCH"/>
+                <EXCEPTION NAME="nbthost" UNKNOWN_EVAL="UNMATCH"/>
+                <EXCEPTION NAME="user" UNKNOWN_EVAL="UNMATCH"/>
+                <EXCEPTION NAME="group" UNKNOWN_EVAL="UNMATCH"/>
+            </INNER_RULE>
+            <INNER_RULE APP_VERSION="8.4.2-668" CACHE_TTL="259200" CACHE_TTL_SYNCED="true" CLASSIFICATION="REG_STATUS" DESCRIPTION="" ID="1365787048394745136" NAME="Failed" NOT_COND_UPDATE="true" RECHECK_MAIN_RULE_DEF="false">
+                <MATCH_TIMING RATE="10800" SKIP_INACTIVE="true"/>
+                <EXPRESSION EXPR_TYPE="NOT">
+                    <!--Rule expression. Rule name is: Failed-->
+                    <EXPRESSION EXPR_TYPE="SIMPLE">
+                        <CONDITION EMPTY_LIST_VALUE="false" FIELD_NAME="connect_ciscovm_exported" INNER_NOT="true" LABEL="Cisco VM Exported" LEFT_PARENTHESIS="0" LOGIC="AND" PLUGIN_NAME="Connect" PLUGIN_UNIQUE_NAME="connect_module" PLUGIN_VESRION="1.7.4" PLUGIN_VESRION_NUMBER="17040015" RET_VALUE_ON_UKNOWN="IRRESOLVED" RIGHT_PARENTHESIS="0">
+                            <FILTER CASE_SENSITIVE="false" FILTER_ID="-6911461059735115145" TYPE="equals">
+                                <VALUE VALUE2="true"/>
+                            </FILTER>
+                        </CONDITION>
+                    </EXPRESSION>
+                </EXPRESSION>
+                <EXCEPTION NAME="ip" UNKNOWN_EVAL="UNMATCH"/>
+                <EXCEPTION NAME="mac" UNKNOWN_EVAL="UNMATCH"/>
+                <EXCEPTION NAME="nbthost" UNKNOWN_EVAL="UNMATCH"/>
+                <EXCEPTION NAME="user" UNKNOWN_EVAL="UNMATCH"/>
+                <EXCEPTION NAME="group" UNKNOWN_EVAL="UNMATCH"/>
+            </INNER_RULE>
+        </RULE_CHAIN>
         <REPORT_TABLES/>
     </RULE>
 </RULES>

--- a/CiscoVM/CiscoVM-1.0.0/policies/nptemplates/ciscovm_exported.xml
+++ b/CiscoVM/CiscoVM-1.0.0/policies/nptemplates/ciscovm_exported.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <RULES>
-    <RULE APP_VERSION="8.4.2-668" CACHE_TTL="259200" CACHE_TTL_SYNCED="true" CLASSIFICATION="REG_STATUS" DESCRIPTION="" ENABLED="true" ID="7949410565485933875" NAME="Cisco VM" NOT_COND_UPDATE="true" UPGRADE_PERFORMED="true">
+    <RULE APP_VERSION="8.4.2-668" CACHE_TTL="259200" CACHE_TTL_SYNCED="true" CLASSIFICATION="REG_STATUS" DESCRIPTION="" ENABLED="true" ID="-5771234825217712406" NAME="Cisco VM Devices" NOT_COND_UPDATE="true" UPGRADE_PERFORMED="true">
         <GROUP_IN_FILTER/>
         <INACTIVITY_TTL TTL="259200000" USE_DEFAULT="true"/>
         <ADMISSION_RESOLVE_DELAY TTL="30000" USE_DEFAULT="true"/>
-        <MATCH_TIMING SKIP_INACTIVE="true"/>
+        <MATCH_TIMING SKIP_INACTIVE="true">
+            <SCHEDULE FREQ="1" HOUR="0" MINUTE="0" REG="1697787993222" TYPE="DAY"/>
+        </MATCH_TIMING>
         <EXPRESSION EXPR_TYPE="SIMPLE">
-            <!--Rule expression. Rule name is: Cisco VM-->
+            <!--Rule expression. Rule name is: Cisco VM Devices-->
             <CONDITION EMPTY_LIST_VALUE="false" FIELD_NAME="connect_ciscovm_exported" LABEL="Cisco VM Exported" LEFT_PARENTHESIS="0" LOGIC="AND" PLUGIN_NAME="Connect" PLUGIN_UNIQUE_NAME="connect_module" PLUGIN_VESRION="1.7.4" PLUGIN_VESRION_NUMBER="17040015" RET_VALUE_ON_UKNOWN="IRRESOLVED" RIGHT_PARENTHESIS="0">
                 <FILTER CASE_SENSITIVE="false" FILTER_ID="-6527407906135295596" TYPE="any">
                     <VALUE VALUE2="Any"/>
@@ -23,25 +25,7 @@
         <RANGE FROM="0.0.0.0" TO="255.255.255.255"/>
         <SUBNET address="::" prefix="0"/>
         <RULE_CHAIN>
-            <INNER_RULE APP_VERSION="8.4.2-668" CACHE_TTL="259200" CACHE_TTL_SYNCED="true" CLASSIFICATION="REG_STATUS" DESCRIPTION="" ID="8984904902782325874" NAME="Exported" NOT_COND_UPDATE="true" RECHECK_MAIN_RULE_DEF="false">
-                <MATCH_TIMING SKIP_INACTIVE="true">
-                    <SCHEDULE FREQ="1" HOUR="0" MINUTE="0" REG="1697743773401" TYPE="DAY"/>
-                </MATCH_TIMING>
-                <EXPRESSION EXPR_TYPE="SIMPLE">
-                    <!--Rule expression. Rule name is: Exported-->
-                    <CONDITION EMPTY_LIST_VALUE="false" FIELD_NAME="connect_ciscovm_exported" LABEL="Cisco VM Exported" LEFT_PARENTHESIS="0" LOGIC="AND" PLUGIN_NAME="Connect" PLUGIN_UNIQUE_NAME="connect_module" PLUGIN_VESRION="1.7.4" PLUGIN_VESRION_NUMBER="17040015" RET_VALUE_ON_UKNOWN="IRRESOLVED" RIGHT_PARENTHESIS="0">
-                        <FILTER CASE_SENSITIVE="false" FILTER_ID="1090314693701632772" TYPE="equals">
-                            <VALUE VALUE2="true"/>
-                        </FILTER>
-                    </CONDITION>
-                </EXPRESSION>
-                <EXCEPTION NAME="ip" UNKNOWN_EVAL="UNMATCH"/>
-                <EXCEPTION NAME="mac" UNKNOWN_EVAL="UNMATCH"/>
-                <EXCEPTION NAME="nbthost" UNKNOWN_EVAL="UNMATCH"/>
-                <EXCEPTION NAME="user" UNKNOWN_EVAL="UNMATCH"/>
-                <EXCEPTION NAME="group" UNKNOWN_EVAL="UNMATCH"/>
-            </INNER_RULE>
-            <INNER_RULE APP_VERSION="8.4.2-668" CACHE_TTL="259200" CACHE_TTL_SYNCED="true" CLASSIFICATION="REG_STATUS" DESCRIPTION="" ID="1365787048394745136" NAME="Failed" NOT_COND_UPDATE="true" RECHECK_MAIN_RULE_DEF="false">
+            <INNER_RULE APP_VERSION="8.4.2-668" CACHE_TTL="259200" CACHE_TTL_SYNCED="true" CLASSIFICATION="REG_STATUS" DESCRIPTION="" ID="-935786635214772550" NAME="Failed" NOT_COND_UPDATE="true" RECHECK_MAIN_RULE_DEF="false">
                 <MATCH_TIMING RATE="10800" SKIP_INACTIVE="true"/>
                 <EXPRESSION EXPR_TYPE="NOT">
                     <!--Rule expression. Rule name is: Failed-->
@@ -53,10 +37,10 @@
                         </CONDITION>
                     </EXPRESSION>
                 </EXPRESSION>
-                <EXCEPTION NAME="ip" UNKNOWN_EVAL="UNMATCH"/>
-                <EXCEPTION NAME="mac" UNKNOWN_EVAL="UNMATCH"/>
                 <EXCEPTION NAME="nbthost" UNKNOWN_EVAL="UNMATCH"/>
+                <EXCEPTION NAME="ip" UNKNOWN_EVAL="UNMATCH"/>
                 <EXCEPTION NAME="user" UNKNOWN_EVAL="UNMATCH"/>
+                <EXCEPTION NAME="mac" UNKNOWN_EVAL="UNMATCH"/>
                 <EXCEPTION NAME="group" UNKNOWN_EVAL="UNMATCH"/>
             </INNER_RULE>
         </RULE_CHAIN>

--- a/CiscoVM/CiscoVM-1.0.0/system.conf
+++ b/CiscoVM/CiscoVM-1.0.0/system.conf
@@ -39,12 +39,12 @@
         {
           "rate limiter": true,
           "display": "Rate limiter",
-          "unit": 1,
+          "unit": 6,
           "min": 1,
-          "max": 1000,
+          "max": 100,
           "add to column": "true",
           "show column": "true",
-          "value": 100,
+          "value": 50,
           "tooltip": "Number of API queries per unit time"
         }
       ]


### PR DESCRIPTION
Based on testing result, it appears that we don't have impact on `irresolvable` assets export retry.
Hence, we should avoid irresolvable status by defining `Cisco VM Exported property` even during the failure.
This way we can apply subrule to the failed records and apply custom recheck interval for this group.